### PR TITLE
Custom Redis store to set TTL

### DIFF
--- a/src/Cache/RedisStore.php
+++ b/src/Cache/RedisStore.php
@@ -38,6 +38,6 @@ class RedisStore extends TusRedisStore
             $this->ttl
         );
 
-        return 'OK' === $status->getPayload();
+        return $status->getPayload() === 'OK';
     }
 }

--- a/src/Cache/RedisStore.php
+++ b/src/Cache/RedisStore.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Tus\Cache;
+
+use TusPhp\Cache\RedisStore as TusRedisStore;
+
+class RedisStore extends TusRedisStore
+{
+    /**
+     * @inheritDoc
+     */
+    public function set(string $key, $value)
+    {
+        $contents = $this->get($key) ?? [];
+
+        if (\is_array($value)) {
+            $contents = $value + $contents;
+        } else {
+            $contents[] = $value;
+        }
+
+        $status = $this->redis->set(
+            $this->getPrefix() . $key,
+            json_encode($contents),
+            'EX',
+            $this->ttl
+        );
+
+        return 'OK' === $status->getPayload();
+    }
+}

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Tus\Http;
 
+use BEdita\Tus\Cache\RedisStore;
 use Cake\Utility\Hash;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use TusPhp\Tus\Server as TusServer;
@@ -96,5 +97,22 @@ class Server extends TusServer
         }
 
         return parent::handleHead();
+    }
+
+    /**
+     * Set cache.
+     *
+     * @param mixed $cache Cache configuration
+     * @return self
+     */
+    public function setCache($cache): self
+    {
+        if ($cache !== 'redis') {
+            return parent::setCache($cache);
+        }
+        $this->cache = new RedisStore();
+        $this->cache->setPrefix('tus:server:');
+
+        return $this;
     }
 }


### PR DESCRIPTION
This PR introduces a new custom `Redis` store that modifies `set()` method in order to add TTL in seconds on keys.
